### PR TITLE
Update CLI board to 12x12 grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Multiplication Bingo
 
-This repository contains a simple script that generates and displays a Bingo board in the console and a small Flask web app that shows a 12x12 grid. The web page also generates a random number between 1 and 144 each time you click the "Next Number" button.
+This repository contains a command-line script that prints a 12x12 grid of numbers and a small Flask web app that shows the same 12x12 grid in the browser. The web page also generates a random number between 1 and 144 each time you click the "Next Number" button.
 
 ## Command-line usage
 

--- a/bingo_board.py
+++ b/bingo_board.py
@@ -1,27 +1,20 @@
-import random
-
-def generate_bingo_board():
+def generate_board():
+    """Return a 12x12 grid with sequential numbers 1..144."""
     board = []
-    ranges = {
-        'B': range(1, 16),
-        'I': range(16, 31),
-        'N': range(31, 46),
-        'G': range(46, 61),
-        'O': range(61, 76)
-    }
-    for letter in 'BINGO':
-        numbers = random.sample(ranges[letter], 5)
-        board.append(numbers)
-    # Set the center space to "FREE"
-    board[2][2] = 'FREE'
+    num = 1
+    for _ in range(12):
+        row = list(range(num, num + 12))
+        board.append(row)
+        num += 12
     return board
 
 def display_board(board):
-    headers = ' '.join(f"{c:^5}" for c in 'BINGO')
-    print(headers)
-    for row in zip(*board):
-        print(' '.join(f"{str(cell):^5}" for cell in row))
+    """Print the board with row and column labels."""
+    header = "    " + " " .join(f"{c:>4}" for c in range(1, 13))
+    print(header)
+    for idx, row in enumerate(board, start=1):
+        print(f"{idx:>3} " + " ".join(f"{cell:>4}" for cell in row))
 
 if __name__ == "__main__":
-    board = generate_bingo_board()
+    board = generate_board()
     display_board(board)


### PR DESCRIPTION
## Summary
- update `bingo_board.py` to print a 12x12 grid and remove the old Bingo board logic
- clarify README that the CLI prints a 12x12 grid

## Testing
- `python3 bingo_board.py | head`

------
https://chatgpt.com/codex/tasks/task_e_6851af30ca38832bbe7c07eb0ff23d5a