### PR TITLE
Update grid to blank cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Multiplication Bingo
 
-This repository contains a simple script that generates and displays a Bingo board in the console and a small Flask web app that shows a 12x12 grid. The web page also generates a random number between 1 and 144 each time you click the "Next Number" button.
+This repository contains a command-line script that prints an empty 12x12 grid with row and column labels and a small Flask web app that displays the same blank grid in the browser. The web page also generates a random number between 1 and 144 each time you click the "Next Number" button.
 
 ## Command-line usage
 

--- a/app.py
+++ b/app.py
@@ -1,22 +1,9 @@
 from flask import Flask, render_template
 
 app = Flask(__name__)
-
-def generate_board():
-    """Return a 12x12 grid with sequential numbers 1..144."""
-    board = []
-    num = 1
-    for _ in range(12):
-        row = list(range(num, num + 12))
-        board.append(row)
-        num += 12
-    return board
-
-
 @app.route('/')
 def index():
-    board = generate_board()
-    return render_template('board.html', board=board)
+    return render_template('board.html')
 
 
 if __name__ == '__main__':

--- a/bingo_board.py
+++ b/bingo_board.py
@@ -1,27 +1,15 @@
-import random
-
-def generate_bingo_board():
-    board = []
-    ranges = {
-        'B': range(1, 16),
-        'I': range(16, 31),
-        'N': range(31, 46),
-        'G': range(46, 61),
-        'O': range(61, 76)
-    }
-    for letter in 'BINGO':
-        numbers = random.sample(ranges[letter], 5)
-        board.append(numbers)
-    # Set the center space to "FREE"
-    board[2][2] = 'FREE'
-    return board
+def generate_board():
+    """Return a 12x12 grid of blank strings."""
+    return [["" for _ in range(12)] for _ in range(12)]
 
 def display_board(board):
-    headers = ' '.join(f"{c:^5}" for c in 'BINGO')
-    print(headers)
-    for row in zip(*board):
-        print(' '.join(f"{str(cell):^5}" for cell in row))
+    """Print the board with row and column labels."""
+    header = "    " + " " .join(f"{c:>4}" for c in range(1, 13))
+    print(header)
+    blank_cell = " " * 4
+    for idx in range(1, 13):
+        print(f"{idx:>3} " + " ".join(blank_cell for _ in range(12)))
 
 if __name__ == "__main__":
-    board = generate_bingo_board()
+    board = generate_board()
     display_board(board)

--- a/templates/board.html
+++ b/templates/board.html
@@ -32,11 +32,11 @@
             </tr>
         </thead>
         <tbody>
-            {% for row in board %}
+            {% for row in range(1, 13) %}
                 <tr>
-                    <th>{{ loop.index }}</th>
-                    {% for cell in row %}
-                        <td>{{ cell }}</td>
+                    <th>{{ row }}</th>
+                    {% for _ in range(12) %}
+                        <td></td>
                     {% endfor %}
                 </tr>
             {% endfor %}


### PR DESCRIPTION
## Summary
- show an empty 12×12 grid in both CLI and web app
- remove board generation logic in the web app
- clarify README for blank grid

## Testing
- `python3 bingo_board.py | head`
- `python3 -m pip install -r requirements.txt`
- `python3 app.py` *(fails: Address already in use)*

------
https://chatgpt.com/codex/tasks/task_e_6851af30ca38832bbe7c07eb0ff23d5a