### PR TITLE
Preserve marked bingo cells when drawing new numbers

### DIFF
--- a/templates/board.html
+++ b/templates/board.html
@@ -41,7 +41,6 @@
             const value = Math.floor(Math.random() * 144) + 1;
             document.getElementById('random-number').textContent = value;
             document.getElementById('feedback').value = '';
-            document.querySelectorAll('td').forEach(td => td.style.backgroundColor = '');
         }
 
         function cellClicked(event) {


### PR DESCRIPTION
## Summary
- keep previously selected cells highlighted on "Next Number"

## Testing
- `python3 -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6851e4ea384c832b91dc3068ef0a0ccb