### PR TITLE
Tweak board size

### DIFF
--- a/templates/board.html
+++ b/templates/board.html
@@ -23,13 +23,16 @@
         }
         table {
             border-collapse: collapse;
-            margin: 1.5em auto 0;
+            margin: 2em auto 0;
+            width: 80vmin;
+            height: 80vmin;
+            table-layout: fixed;
         }
         th, td {
             border: 1px solid #ccc;
-            padding: 10px;
+            padding: 0;
             text-align: center;
-            font-size: 1.2em;
+            font-size: 1.4em;
         }
         .feedback {
             margin-top: 1em;


### PR DESCRIPTION
## Summary
- slightly shrink the bingo board so it doesn't fill the entire screen

## Testing
- `python3 -m py_compile bingo_board.py app.py`
- `python3 app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6851ee5432ec832ba15564b6adfa25dc