### PR TITLE
Add factor labels to bingo board

### DIFF
--- a/bingo_board.py
+++ b/bingo_board.py
@@ -1,14 +1,22 @@
 def generate_board():
-    """Return a 12x12 grid of blank strings."""
-    return [["" for _ in range(12)] for _ in range(12)]
+    """Return a 12x12 grid with factor labels."""
+    board = []
+    for row in range(1, 13):
+        row_data = []
+        for col in range(1, 13):
+            if row >= col:
+                row_data.append(f"{row}×{col}")
+            else:
+                row_data.append(f"{col}×{row}")
+        board.append(row_data)
+    return board
 
 def display_board(board):
     """Print the board with row and column labels."""
-    header = "    " + " " .join(f"{c:>4}" for c in range(1, 13))
+    header = " " * 5 + " ".join(f"{c:>7}" for c in range(1, 13))
     print(header)
-    blank_cell = " " * 4
-    for idx in range(1, 13):
-        print(f"{idx:>3} " + " ".join(blank_cell for _ in range(12)))
+    for idx, row in enumerate(board, start=1):
+        print(f"{idx:>3} " + " ".join(f"{cell:>7}" for cell in row))
 
 if __name__ == "__main__":
     board = generate_board()

--- a/templates/board.html
+++ b/templates/board.html
@@ -176,7 +176,11 @@
                 <tr>
                     <th>{{ row }}</th>
                     {% for col in range(1, 13) %}
-                        <td data-row="{{ row }}" data-col="{{ col }}"></td>
+                        {% if row >= col %}
+                            <td data-row="{{ row }}" data-col="{{ col }}">{{ row }} &times; {{ col }}</td>
+                        {% else %}
+                            <td data-row="{{ row }}" data-col="{{ col }}">{{ col }} &times; {{ row }}</td>
+                        {% endif %}
                     {% endfor %}
                 </tr>
             {% endfor %}


### PR DESCRIPTION
## Summary
- populate each board cell with the two factors in descending order
- update the CLI board to show factor labels

## Testing
- `python3 bingo_board.py | head -n 5`
- `pip install -q -r requirements.txt` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6851f12d4468832ba8ee500fc0995fe2