### PR TITLE
Display multiplication products

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Multiplication Bingo
 
-This repository contains a command-line script that prints an empty 12x12 grid with row and column labels and a small Flask web app that displays the same blank grid in the browser. The web page also generates a random number between 1 and 144 each time you click the "Next Number" button.
+This repository contains a command-line script that prints a 12x12 multiplication table and a small Flask web app that displays the same table in the browser. The web page also generates a random number between 1 and 144 each time you click the "Next Number" button.
 
 ## Command-line usage
 

--- a/bingo_board.py
+++ b/bingo_board.py
@@ -1,13 +1,10 @@
 def generate_board():
-    """Return a 12x12 grid with factor labels."""
+    """Return a 12x12 grid with multiplication products."""
     board = []
     for row in range(1, 13):
         row_data = []
         for col in range(1, 13):
-            if row >= col:
-                row_data.append(f"{row}×{col}")
-            else:
-                row_data.append(f"{col}×{row}")
+            row_data.append(str(row * col))
         board.append(row_data)
     return board
 

--- a/templates/board.html
+++ b/templates/board.html
@@ -176,11 +176,7 @@
                 <tr>
                     <th>{{ row }}</th>
                     {% for col in range(1, 13) %}
-                        {% if row >= col %}
-                            <td data-row="{{ row }}" data-col="{{ col }}">{{ row }} &times; {{ col }}</td>
-                        {% else %}
-                            <td data-row="{{ row }}" data-col="{{ col }}">{{ col }} &times; {{ row }}</td>
-                        {% endif %}
+                        <td data-row="{{ row }}" data-col="{{ col }}">{{ row * col }}</td>
                     {% endfor %}
                 </tr>
             {% endfor %}


### PR DESCRIPTION
## Summary
- update board generation to show multiplication products
- display products instead of equations in the web UI
- adjust README wording

## Testing
- `python3 -m py_compile bingo_board.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_685203f7ed30832b9d7b06814885a9ac