### PR TITLE
Change Bingo win condition to 12 cells in a row

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Multiplication Bingo
 
-This repository contains a command-line script that prints a 12x12 multiplication table and a small Flask web app that displays the same table in the browser. The web page also generates a random number between 1 and 144 each time you click the "Next Number" button.
+This repository contains a command-line script that prints a 12x12 multiplication table and a small Flask web app that displays the same table in the browser. The web page also generates a random number between 1 and 144 each time you click the "Next Number" button. Mark the matching cell for each number; if you fill in 12 consecutive cells horizontally, vertically, or diagonally, you win.
 
 ## Command-line usage
 

--- a/templates/board.html
+++ b/templates/board.html
@@ -95,7 +95,7 @@
         }
 
         function checkDirection(r, c, rStep, cStep) {
-            for (let i = 0; i < 5; i++) {
+            for (let i = 0; i < 12; i++) {
                 const nr = r + i * rStep;
                 const nc = c + i * cStep;
                 if (
@@ -112,30 +112,14 @@
         }
 
         function checkForBingo() {
-            // horizontal
             for (let r = 0; r < 12; r++) {
-                for (let c = 0; c <= 7; c++) {
-                    if (checkDirection(r, c, 0, 1)) return true;
-                }
+                if (checkDirection(r, 0, 0, 1)) return true;
             }
-            // vertical
             for (let c = 0; c < 12; c++) {
-                for (let r = 0; r <= 7; r++) {
-                    if (checkDirection(r, c, 1, 0)) return true;
-                }
+                if (checkDirection(0, c, 1, 0)) return true;
             }
-            // diagonal down-right
-            for (let r = 0; r <= 7; r++) {
-                for (let c = 0; c <= 7; c++) {
-                    if (checkDirection(r, c, 1, 1)) return true;
-                }
-            }
-            // diagonal down-left
-            for (let r = 0; r <= 7; r++) {
-                for (let c = 4; c < 12; c++) {
-                    if (checkDirection(r, c, 1, -1)) return true;
-                }
-            }
+            if (checkDirection(0, 0, 1, 1)) return true;
+            if (checkDirection(0, 11, 1, -1)) return true;
             return false;
         }
 
@@ -182,6 +166,6 @@
             {% endfor %}
         </tbody>
     </table>
-    <div id="bingo-message" class="bingo-message">Bingo! You win!</div>
+    <div id="bingo-message" class="bingo-message">Bingo! 12 in a row!</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update README to describe 12-in-a-row rule
- restore board logic to look for 12 consecutive marked cells
- show a message when you get 12 in a row

## Testing
- `python3 -m compileall -q .`
- `python3 -m py_compile app.py bingo_board.py`


------
https://chatgpt.com/codex/tasks/task_e_6852e2b4b084832b9ce2ea877277a1e7