### PR TITLE
Improve responsiveness of bingo board

### DIFF
--- a/templates/board.html
+++ b/templates/board.html
@@ -2,15 +2,19 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Multiplication Bingo</title>
     <style>
         body {
+            margin: 0;
+            padding: 0;
             display: flex;
             flex-direction: column;
             align-items: center;
             justify-content: flex-start;
             min-height: 100vh;
             font-family: sans-serif;
+            font-size: 2vmin;
         }
         h1 {
             font-size: 2.5em;
@@ -24,8 +28,10 @@
         table {
             border-collapse: collapse;
             margin: 2em auto 0;
-            width: 80vmin;
-            height: 80vmin;
+            width: 90vmin;
+            height: 90vmin;
+            max-width: 90vw;
+            max-height: 90vh;
             table-layout: fixed;
         }
         th, td {


### PR DESCRIPTION
## Summary
- reset body margin/padding so layout uses full viewport
- enlarge the table and cap its size using viewport units

## Testing
- `python3 bingo_board.py`
- `pip install -r requirements.txt`
- `python3 app.py` *(fails: address already in use)*

------
https://chatgpt.com/codex/tasks/task_e_6852f26d4890832b826dfc7bb6fb34ab