### PR TITLE
Extend correct feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Multiplication Bingo
 
-This repository contains a command-line script that prints a 12x12 multiplication table and a small Flask web app that displays the same table in the browser. The web page also generates a random number between 1 and 144 each time you click the "Next Number" button.
+This repository contains a command-line script that prints a 12x12 multiplication table and a small Flask web app that displays the same table in the browser. The web page generates a random number between 1 and 144, and a new one is drawn whenever you correctly select the matching product on the board. When you get a match, the message "Correct!" stays on screen for a few seconds before the next number shows up.
 
 To win the bingo game you must mark a complete line of twelve correct cells in a row, horizontally, vertically or diagonally.
 
@@ -30,6 +30,6 @@ python3 -m pip install -r requirements.txt
 python3 app.py
 ```
 
-3. Open <http://localhost:5000/> in a web browser to view the board. Click "Next Number" to draw a new random number on the page.
+3. Open <http://localhost:5000/> in a web browser to view the board. A random number is shown at the top of the page and a new one is generated when you click the correct cell.
 
 For deployment, host the app on any platform that supports Flask applications (Heroku, Fly.io, etc.) and ensure the environment installs the dependency and runs `python3 app.py` or uses a production server like Gunicorn.

--- a/templates/board.html
+++ b/templates/board.html
@@ -56,7 +56,6 @@
     </style>
     <script>
         const boardState = Array.from({ length: 12 }, () => Array(12).fill(false));
-        let selectionLocked = false;
         let numberBag = [];
 
         function shuffle(array) {
@@ -83,7 +82,6 @@
             const value = numberBag.pop();
             document.getElementById('random-number').textContent = value;
             document.getElementById('feedback').value = '';
-            selectionLocked = false;
         }
 
         function cellClicked(event) {
@@ -95,23 +93,17 @@
                 10
             );
             const feedbackEl = document.getElementById('feedback');
-            if (selectionLocked) {
-                feedbackEl.value = "Generate a new number first!";
-                return;
-            }
             if (row * col === randomValue) {
                 cell.style.backgroundColor = 'lightgreen';
                 boardState[row - 1][col - 1] = true;
-                selectionLocked = true;
-                feedbackEl.value = 'Correct! Generate a new number';
+                feedbackEl.value = 'Correct!';
                 if (checkForBingo()) {
                     showBingoMessage();
+                } else {
+                    setTimeout(generateNumber, 3000);
                 }
             } else {
                 feedbackEl.value = 'Incorrect! Try again!';
-            }
-            if (checkForBingo()) {
-                showBingoMessage();
             }
         }
 
@@ -168,7 +160,6 @@
     <h1>Multiplication Bingo</h1>
     <div class="number-display">
         Random Number: <span id="random-number"></span>
-        <button onclick="generateNumber()">Next Number</button>
     </div>
     <input type="text" id="feedback" class="feedback" readonly>
     <table>


### PR DESCRIPTION
## Summary
- show "Correct!" for 3 seconds before generating next number
- clarify README that feedback stays on screen for a few seconds

## Testing
- `python3 -m py_compile app.py bingo_board.py`


------
https://chatgpt.com/codex/tasks/task_e_685306170574832bac51199d24d40ac1