### PR TITLE
Add intro page with easy/hard modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ python3 -m pip install -r requirements.txt
 python3 app.py
 ```
 
-3. Open <http://localhost:5000/> in a web browser to view the board. A random number is shown at the top of the page and a new one is generated when you click the correct cell.
+4. Open <http://localhost:5000/> in a web browser. You'll be greeted with a welcome screen offering "Easy" or "Hard" mode. Easy mode shows the multiplication products on the bingo board while Hard mode leaves the squares blank.
 
 For deployment, host the app on any platform that supports Flask applications (Heroku, Fly.io, etc.) and ensure the environment installs the dependency and runs `python3 app.py` or uses a production server like Gunicorn.

--- a/app.py
+++ b/app.py
@@ -3,7 +3,17 @@ from flask import Flask, render_template
 app = Flask(__name__)
 @app.route('/')
 def index():
-    return render_template('board.html')
+    return render_template('index.html')
+
+
+@app.route('/easy')
+def easy_mode():
+    return render_template('board.html', show_products=True)
+
+
+@app.route('/hard')
+def hard_mode():
+    return render_template('board.html', show_products=False)
 
 
 if __name__ == '__main__':

--- a/templates/board.html
+++ b/templates/board.html
@@ -176,7 +176,7 @@
                 <tr>
                     <th>{{ row }}</th>
                     {% for col in range(1, 13) %}
-                        <td data-row="{{ row }}" data-col="{{ col }}">{{ row * col }}</td>
+                        <td data-row="{{ row }}" data-col="{{ col }}">{% if show_products %}{{ row * col }}{% endif %}</td>
                     {% endfor %}
                 </tr>
             {% endfor %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Multiplication Bingo</title>
+    <style>
+        body {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            font-family: sans-serif;
+            text-align: center;
+        }
+        h1 {
+            margin-bottom: 2em;
+            max-width: 40ch;
+        }
+        .mode-buttons {
+            display: flex;
+            gap: 2em;
+        }
+        .mode-buttons a {
+            display: inline-block;
+            padding: 1em 2em;
+            background: #007BFF;
+            color: white;
+            text-decoration: none;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Welcome to Mike's Math Club! The game you are about to play is Multiplication Bingo. Let's see how well you know your multiplication table's. Please select your game mode.</h1>
+    <div class="mode-buttons">
+        <a href="{{ url_for('easy_mode') }}">Easy Mode</a>
+        <a href="{{ url_for('hard_mode') }}">Hard Mode</a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an index page that lets the user choose Easy or Hard mode
- show multiplication products on the board only in Easy mode
- wire new endpoints `/easy` and `/hard`
- update README instructions

## Testing
- `python3 -m pip install -r requirements.txt`
- `pytest -q`
- `python3 -m py_compile app.py bingo_board.py`


------
https://chatgpt.com/codex/tasks/task_e_685311c37624832b8ec69d6ea1e12079