### PR TITLE
Add colors to bingo board

### DIFF
--- a/templates/board.html
+++ b/templates/board.html
@@ -11,6 +11,7 @@
             justify-content: flex-start;
             min-height: 100vh;
             font-family: sans-serif;
+            background-color: #f0f8ff;
         }
         h1 {
             font-size: 2.5em;
@@ -20,6 +21,7 @@
         .number-display {
             margin: 0.5em 0 1em;
             font-size: 1.4em;
+            color: #0056b3;
         }
         table {
             border-collapse: collapse;
@@ -33,6 +35,18 @@
             padding: 0;
             text-align: center;
             font-size: 1.4em;
+        }
+        thead th,
+        tbody th {
+            background-color: #e2eafc;
+            color: #007BFF;
+        }
+        td {
+            background-color: #ffffff;
+        }
+        td:hover {
+            background-color: #f0f0f0;
+            cursor: pointer;
         }
         .feedback {
             margin-top: 1em;

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,10 +12,12 @@
             min-height: 100vh;
             font-family: sans-serif;
             text-align: center;
+            background-color: #f0f8ff;
         }
         h1 {
             margin-bottom: 2em;
             max-width: 40ch;
+            color: #0056b3;
         }
         .mode-buttons {
             display: flex;


### PR DESCRIPTION
## Summary
- style headers for row and column numbers in the board
- tweak table hover effects and random number color
- add blue background to pages for a little color

## Testing
- `python3 -m py_compile app.py bingo_board.py`

------
https://chatgpt.com/codex/tasks/task_e_6853357653e8832ba923c9980d4e2d23