### PR TITLE
Add fonts and adjust header colors

### DIFF
--- a/templates/board.html
+++ b/templates/board.html
@@ -10,16 +10,19 @@
             align-items: center;
             justify-content: flex-start;
             min-height: 100vh;
-            font-family: sans-serif;
+            font-family: Arial, sans-serif;
+            background-color: #f0f8ff;
         }
         h1 {
             font-size: 2.5em;
             margin-top: 1em;
             margin-bottom: 0.5em;
+            font-family: "Trebuchet MS", "Lucida Sans Unicode", "Lucida Grande", sans-serif;
         }
         .number-display {
             margin: 0.5em 0 1em;
             font-size: 1.4em;
+            color: #0056b3;
         }
         table {
             border-collapse: collapse;
@@ -33,6 +36,18 @@
             padding: 0;
             text-align: center;
             font-size: 1.4em;
+        }
+        thead th,
+        tbody th {
+            background-color: #007BFF;
+            color: #ffffff;
+        }
+        td {
+            background-color: #ffffff;
+        }
+        td:hover {
+            background-color: #f0f0f0;
+            cursor: pointer;
         }
         .feedback {
             margin-top: 1em;

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,12 +10,15 @@
             align-items: center;
             justify-content: center;
             min-height: 100vh;
-            font-family: sans-serif;
+            font-family: Arial, sans-serif;
             text-align: center;
+            background-color: #f0f8ff;
         }
         h1 {
             margin-bottom: 2em;
             max-width: 40ch;
+            color: #0056b3;
+            font-family: "Trebuchet MS", "Lucida Sans Unicode", "Lucida Grande", sans-serif;
         }
         .mode-buttons {
             display: flex;


### PR DESCRIPTION
## Summary
- style row and column headers with a stronger color
- set distinct fonts for titles on the board and intro screens

## Testing
- `python3 -m py_compile app.py bingo_board.py`


------
https://chatgpt.com/codex/tasks/task_e_6853357653e8832ba923c9980d4e2d23