### PR TITLE
Adjust column header size

### DIFF
--- a/templates/board.html
+++ b/templates/board.html
@@ -15,12 +15,12 @@
         }
         h1 {
             font-size: 2.5em;
-            margin-top: 1em;
-            margin-bottom: 0.5em;
+            margin-top: 0.5em;
+            margin-bottom: 0.25em;
             font-family: "Trebuchet MS", "Lucida Sans Unicode", "Lucida Grande", sans-serif;
         }
         .number-display {
-            margin: 0.5em 0 1em;
+            margin: 0.25em 0 1em;
             font-size: 1.4em;
             color: #0056b3;
         }
@@ -45,6 +45,11 @@
         .col-header,
         .row-header {
             font-size: 1em;
+        }
+        .col-header,
+        thead th:first-child {
+            height: 6vmin;
+            line-height: 6vmin;
         }
         td {
             background-color: #ffffff;


### PR DESCRIPTION
## Summary
- enlarge column header boxes to match row indicators
- shift title and random number upward slightly to avoid overlap

## Testing
- `python3 -m py_compile app.py bingo_board.py`

------
https://chatgpt.com/codex/tasks/task_e_6853423befac832b9a072d7bf82c93ff