### PR TITLE
Fix repeated clicks generating extra numbers

### DIFF
--- a/templates/board.html
+++ b/templates/board.html
@@ -118,6 +118,9 @@
             const cell = event.target;
             const row = parseInt(cell.dataset.row, 10);
             const col = parseInt(cell.dataset.col, 10);
+            if (boardState[row - 1][col - 1]) {
+                return;
+            }
             const randomValue = parseInt(
                 document.getElementById('random-number').textContent,
                 10


### PR DESCRIPTION
## Summary
- ignore click events if the cell is already marked correct

This prevents extra scheduled calls to `generateNumber()` when the same
cell is clicked multiple times, so the random number won't unexpectedly
change.

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68559a1fcde4832b9203e00378788dda