### PR TITLE
Add sound feedback to bingo board

### DIFF
--- a/templates/board.html
+++ b/templates/board.html
@@ -88,6 +88,46 @@
         const boardState = Array.from({ length: 12 }, () => Array(12).fill(false));
         let numberBag = [];
 
+        let audioCtx;
+        function playTone(freq, duration, type = 'sine', delay = 0) {
+            audioCtx = audioCtx || new (window.AudioContext || window.webkitAudioContext)();
+            const osc = audioCtx.createOscillator();
+            const gain = audioCtx.createGain();
+            const start = audioCtx.currentTime + delay / 1000;
+            const end = start + duration / 1000;
+            osc.type = type;
+            osc.frequency.setValueAtTime(freq, start);
+            osc.connect(gain);
+            gain.connect(audioCtx.destination);
+            gain.gain.setValueAtTime(1, start);
+            gain.gain.exponentialRampToValueAtTime(0.001, end);
+            osc.start(start);
+            osc.stop(end);
+        }
+
+        function playCorrectSound() {
+            playTone(1046, 300, 'triangle');
+        }
+
+        function playIncorrectSound() {
+            playTone(440, 150, 'sawtooth');
+            playTone(330, 200, 'sawtooth', 150);
+        }
+
+        function playWinSound() {
+            const melody = [
+                { f: 523.25, d: 200 },
+                { f: 659.25, d: 200 },
+                { f: 783.99, d: 200 },
+                { f: 1046.5, d: 400 }
+            ];
+            let delay = 0;
+            melody.forEach(n => {
+                playTone(n.f, n.d, 'triangle', delay);
+                delay += n.d;
+            });
+        }
+
         function shuffle(array) {
             for (let i = array.length - 1; i > 0; i--) {
                 const j = Math.floor(Math.random() * (i + 1));
@@ -130,6 +170,7 @@
                 cell.style.backgroundColor = 'lightgreen';
                 boardState[row - 1][col - 1] = true;
                 feedbackEl.value = 'Correct!';
+                playCorrectSound();
                 if (checkForBingo()) {
                     showBingoMessage();
                 } else {
@@ -137,6 +178,7 @@
                 }
             } else {
                 feedbackEl.value = 'Incorrect! Try again!';
+                playIncorrectSound();
             }
         }
 
@@ -176,6 +218,7 @@
         function showBingoMessage() {
             const el = document.getElementById('bingo-message');
             el.style.visibility = 'visible';
+            playWinSound();
             document
                 .querySelectorAll('td')
                 .forEach(td => td.removeEventListener('click', cellClicked));


### PR DESCRIPTION
## Summary
- add a small audio helper using the Web Audio API
- play a short tone on correct and incorrect picks
- play a fanfare when bingo is achieved

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68559c873df8832b8e1486c8272afe1c