### PR TITLE
Add bottom and right grid indicators

### DIFF
--- a/templates/board.html
+++ b/templates/board.html
@@ -265,8 +265,16 @@
                     {% for col in range(1, 13) %}
                         <td data-row="{{ row }}" data-col="{{ col }}">{% if show_products %}{{ row * col }}{% endif %}</td>
                     {% endfor %}
+                    <th class="row-header">{{ row }}</th>
                 </tr>
             {% endfor %}
+            <tr>
+                <th></th>
+                {% for col in range(1, 13) %}
+                    <th class="col-header">{{ col }}</th>
+                {% endfor %}
+                <th></th>
+            </tr>
         </tbody>
     </table>
     <div id="bingo-message" class="bingo-message">


### PR DESCRIPTION
## Summary
- add row indicators on the right side of the grid
- add column indicators to the bottom of the grid

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 bingo_board.py`
- `python3 app.py & sleep 5`

------
https://chatgpt.com/codex/tasks/task_e_6855a2cc8a70832b9bf64b5fd5130a01