### PR TITLE
Add answer timer to bingo game

### DIFF
--- a/templates/board.html
+++ b/templates/board.html
@@ -98,6 +98,9 @@
     <script>
         const boardState = Array.from({ length: 12 }, () => Array(12).fill(false));
         let numberBag = [];
+        let answerTimeout;
+        let timerInterval;
+        let timeLeft = 15;
 
         let audioCtx;
         function playTone(freq, duration, type = 'sine', delay = 0) {
@@ -147,6 +150,10 @@
             }
         }
 
+        function updateTimerDisplay() {
+            document.getElementById('timer').textContent = timeLeft;
+        }
+
         function initializeBag() {
             numberBag = [];
             for (let r = 1; r <= 12; r++) {
@@ -164,6 +171,20 @@
             const value = numberBag.pop();
             document.getElementById('random-number').textContent = value;
             document.getElementById('feedback').value = '';
+            clearTimeout(answerTimeout);
+            clearInterval(timerInterval);
+            timeLeft = 15;
+            updateTimerDisplay();
+            answerTimeout = setTimeout(() => {
+                generateNumber();
+            }, 15000);
+            timerInterval = setInterval(() => {
+                timeLeft--;
+                if (timeLeft <= 0) {
+                    clearInterval(timerInterval);
+                }
+                updateTimerDisplay();
+            }, 1000);
         }
 
         let hoverTimer;
@@ -211,6 +232,8 @@
                 boardState[row - 1][col - 1] = true;
                 feedbackEl.value = 'Correct!';
                 playCorrectSound();
+                clearTimeout(answerTimeout);
+                clearInterval(timerInterval);
                 if (checkForBingo()) {
                     showBingoMessage();
                 } else {
@@ -259,6 +282,8 @@
             const el = document.getElementById('bingo-message');
             el.style.visibility = 'visible';
             playWinSound();
+            clearTimeout(answerTimeout);
+            clearInterval(timerInterval);
             document
                 .querySelectorAll('td')
                 .forEach(td => td.removeEventListener('click', cellClicked));
@@ -290,6 +315,7 @@
     <h1>Multiplication Bingo</h1>
     <div class="number-display">
         Random Number: <span id="random-number"></span>
+        | Time Left: <span id="timer">15</span>s
     </div>
     <input type="text" id="feedback" class="feedback" readonly>
     <table>


### PR DESCRIPTION
## Summary
- add 15 second countdown timer to each round
- clear timer when a correct answer is given or the game ends
- display the remaining time in the UI

## Testing
- `python3 -m py_compile bingo_board.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6855a5d7e010832ba94ff545ba443d58