### PR TITLE
Play incorrect sound on timer timeout

### DIFF
--- a/templates/board.html
+++ b/templates/board.html
@@ -176,6 +176,7 @@
             timeLeft = 15;
             updateTimerDisplay();
             answerTimeout = setTimeout(() => {
+                playIncorrectSound();
                 generateNumber();
             }, 15000);
             timerInterval = setInterval(() => {


### PR DESCRIPTION
## Summary
- play the incorrect sound when the 15-second timer expires

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855a8521290832b9aabd7fb0363f4c3