### PR TITLE
Add stopwatch timer to Bingo board

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains a command-line script that prints a 12x12 multiplicatio
 
 To win the bingo game you must mark a complete line of twelve correct cells in a row, horizontally, vertically or diagonally.
 
+The board page also shows a stopwatch in the upper left corner so you can see how long it takes to win. The timer starts when the board loads and stops once you hit Bingo.
+
 ## Command-line usage
 
 ```bash

--- a/templates/board.html
+++ b/templates/board.html
@@ -83,6 +83,16 @@
             font-size: 0.3em;
             padding: 0.5em 1em;
         }
+        #final-time {
+            font-size: 0.3em;
+            margin-top: 0.2em;
+        }
+        #stopwatch {
+            position: fixed;
+            top: 0.5em;
+            left: 0.5em;
+            font-size: 1.2em;
+        }
         .tooltip {
             position: absolute;
             background: rgba(0, 0, 0, 0.75);
@@ -152,6 +162,25 @@
 
         function updateTimerDisplay() {
             document.getElementById('timer').textContent = timeLeft;
+        }
+
+        let stopwatchInterval;
+        let startTime;
+
+        function updateStopwatch() {
+            const elapsed = Math.floor((Date.now() - startTime) / 1000);
+            document.getElementById('stopwatch').textContent = `Time: ${elapsed}s`;
+        }
+
+        function startStopwatch() {
+            startTime = Date.now();
+            updateStopwatch();
+            stopwatchInterval = setInterval(updateStopwatch, 1000);
+        }
+
+        function stopStopwatch() {
+            clearInterval(stopwatchInterval);
+            return Math.floor((Date.now() - startTime) / 1000);
         }
 
         function initializeBag() {
@@ -282,6 +311,8 @@
         function showBingoMessage() {
             const el = document.getElementById('bingo-message');
             el.style.visibility = 'visible';
+            const finalTime = stopStopwatch();
+            document.getElementById('final-time').textContent = `Your time: ${finalTime}s`;
             playWinSound();
             clearTimeout(answerTimeout);
             clearInterval(timerInterval);
@@ -302,6 +333,7 @@
                 return;
             }
             generateNumber();
+            startStopwatch();
             document
                 .querySelectorAll('td')
                 .forEach(td => {
@@ -313,6 +345,7 @@
     </script>
 </head>
 <body>
+    <div id="stopwatch">Time: 0s</div>
     <h1>Multiplication Bingo</h1>
     <div class="number-display">
         Random Number: <span id="random-number"></span>
@@ -349,6 +382,7 @@
     </table>
     <div id="bingo-message" class="bingo-message">
         <div>Bingo! You Win!</div>
+        <div id="final-time"></div>
         <button onclick="window.location.href='{{ url_for('index') }}'">
             New Game
         </button>


### PR DESCRIPTION
## Summary
- show a stopwatch on the board page
- stop and display the final time when Bingo is achieved

## Testing
- `python3 -m py_compile bingo_board.py app.py`
- `python3 -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6855a9759dd8832b9752c13f875acb42