### PR TITLE
Implement leaderboard feature

### DIFF
--- a/scores.json
+++ b/scores.json
@@ -1,0 +1,1 @@
+{"fastest": [], "fewest": []}

--- a/templates/board.html
+++ b/templates/board.html
@@ -348,6 +348,29 @@
             document
                 .querySelectorAll('td')
                 .forEach(td => td.removeEventListener('click', cellClicked));
+            checkHighScore(finalTime, correctCount);
+        }
+
+        function checkHighScore(time, count) {
+            fetch(`/check_score?time=${time}&count=${count}`)
+                .then(r => r.json())
+                .then(res => {
+                    if (res.fastest || res.fewest) {
+                        const entry = document.getElementById('name-entry');
+                        entry.style.display = 'block';
+                        document.getElementById('submit-score').onclick = () => {
+                            const name = document.getElementById('player-name').value || 'Anonymous';
+                            fetch('/submit_score', {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ name, time, count })
+                            }).then(() => {
+                                document.getElementById('score-message').textContent = 'Score saved!';
+                                document.getElementById('submit-score').disabled = true;
+                            });
+                        };
+                    }
+                });
         }
 
         window.addEventListener('DOMContentLoaded', () => {
@@ -418,6 +441,12 @@
         <button onclick="window.location.href='{{ url_for('index') }}'">
             New Game
         </button>
+        <div id="name-entry" style="display:none; font-size:0.3em; margin-top:0.5em;">
+            <div>Leaderboard! Enter your name:</div>
+            <input id="player-name" type="text" style="font-size:1em;" />
+            <button id="submit-score" style="font-size:1em;">Submit</button>
+            <div id="score-message"></div>
+        </div>
     </div>
     <div id="tooltip" class="tooltip"></div>
 </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -39,6 +39,7 @@
     <div class="mode-buttons">
         <a href="{{ url_for('easy_mode') }}">Easy Mode</a>
         <a href="{{ url_for('hard_mode') }}">Hard Mode</a>
+        <a href="{{ url_for('leaderboard') }}">Leaderboard</a>
     </div>
 </body>
 </html>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Leaderboard</title>
+    <style>
+        body { font-family: Arial, sans-serif; background:#f0f8ff; text-align:center; }
+        h1 { margin-top:1em; }
+        table { margin:1em auto; border-collapse:collapse; }
+        th, td { border:1px solid #ccc; padding:0.5em 1em; }
+    </style>
+</head>
+<body>
+    <h1>Leaderboard</h1>
+    <h2>Fastest Times</h2>
+    <table>
+        <tr><th>Rank</th><th>Name</th><th>Time (s)</th></tr>
+        {% for entry in fastest %}
+        <tr><td>{{ loop.index }}</td><td>{{ entry.name }}</td><td>{{ entry.time }}</td></tr>
+        {% endfor %}
+    </table>
+    <h2>Fewest Correct Squares</h2>
+    <table>
+        <tr><th>Rank</th><th>Name</th><th>Squares</th></tr>
+        {% for entry in fewest %}
+        <tr><td>{{ loop.index }}</td><td>{{ entry.name }}</td><td>{{ entry.count }}</td></tr>
+        {% endfor %}
+    </table>
+    <p><a href="{{ url_for('index') }}">Back to Home</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a leaderboard page showing top players
- record scores in `scores.json`
- check and submit scores from the game board
- link leaderboard from the home page

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855c0d7f9a4832b85e3753c57660ce0