### PR TITLE
Update leaderboard to show minutes:seconds

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,15 +15,24 @@ def save_scores(data):
         json.dump(data, f)
 
 app = Flask(__name__)
+
 @app.route('/')
 def index():
     return render_template('index.html')
+
+
+def format_time(seconds):
+    minutes = seconds // 60
+    secs = seconds % 60
+    return f"{minutes}:{secs:02d}"
 
 
 @app.route('/leaderboard')
 def leaderboard():
     scores = load_scores()
     fastest = sorted(scores.get('fastest', []), key=lambda x: x['time'])[:20]
+    for entry in fastest:
+        entry['formatted_time'] = format_time(entry['time'])
     fewest = sorted(scores.get('fewest', []), key=lambda x: x['count'])[:20]
     return render_template('leaderboard.html', fastest=fastest, fewest=fewest)
 

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -36,9 +36,9 @@
         <div class="time-board">
             <h2>Fastest Times</h2>
             <table>
-                <tr><th>Rank</th><th>Name</th><th>Time (s)</th></tr>
+                <tr><th>Rank</th><th>Name</th><th>Time (s)</th><th>Time (mm:ss)</th></tr>
                 {% for entry in fastest %}
-                <tr><td>{{ loop.index }}</td><td>{{ entry.name }}</td><td>{{ entry.time }}</td></tr>
+                <tr><td>{{ loop.index }}</td><td>{{ entry.name }}</td><td>{{ entry.time }}</td><td>{{ entry.formatted_time }}</td></tr>
                 {% endfor %}
             </table>
         </div>


### PR DESCRIPTION
## Summary
- show minutes and seconds on the leaderboard
- add helper to format time and include formatted times in template

## Testing
- `python3 -m py_compile app.py bingo_board.py`
- `python3 -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6855d3976068832b8cb7b57fbd7c5258