### PR TITLE
Update leaderboard time display

### DIFF
--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -36,9 +36,9 @@
         <div class="time-board">
             <h2>Fastest Times</h2>
             <table>
-                <tr><th>Rank</th><th>Name</th><th>Time (s)</th><th>Time (mm:ss)</th></tr>
+                <tr><th>Rank</th><th>Name</th><th>Time (mm:ss)</th></tr>
                 {% for entry in fastest %}
-                <tr><td>{{ loop.index }}</td><td>{{ entry.name }}</td><td>{{ entry.time }}</td><td>{{ entry.formatted_time }}</td></tr>
+                <tr><td>{{ loop.index }}</td><td>{{ entry.name }}</td><td>{{ entry.formatted_time }}</td></tr>
                 {% endfor %}
             </table>
         </div>


### PR DESCRIPTION
## Summary
- remove seconds-only column from leaderboard table

## Testing
- `python3 -m py_compile app.py bingo_board.py`

------
https://chatgpt.com/codex/tasks/task_e_6855d44b2d9c832bb635ddab2f20c225