### PR TITLE
Add mode to leaderboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,7 +33,10 @@ def leaderboard():
     fastest = sorted(scores.get('fastest', []), key=lambda x: x['time'])[:20]
     for entry in fastest:
         entry['formatted_time'] = format_time(entry['time'])
+        entry['mode'] = entry.get('mode', 'Unknown')
     fewest = sorted(scores.get('fewest', []), key=lambda x: x['count'])[:20]
+    for entry in fewest:
+        entry['mode'] = entry.get('mode', 'Unknown')
     return render_template('leaderboard.html', fastest=fastest, fewest=fewest)
 
 
@@ -69,6 +72,7 @@ def submit_score():
     name = data.get('name', 'Anonymous')[:20]
     time = int(data.get('time', 0))
     count = int(data.get('count', 0))
+    mode = data.get('mode', 'Unknown')
 
     scores = load_scores()
     fast = scores.setdefault('fastest', [])
@@ -77,12 +81,12 @@ def submit_score():
     if len(fast) < 20 or time < max(fast, key=lambda x: x['time'])['time']:
         if len(fast) >= 20:
             fast.remove(max(fast, key=lambda x: x['time']))
-        fast.append({'name': name, 'time': time})
+        fast.append({'name': name, 'time': time, 'mode': mode})
 
     if len(few) < 20 or count < max(few, key=lambda x: x['count'])['count']:
         if len(few) >= 20:
             few.remove(max(few, key=lambda x: x['count']))
-        few.append({'name': name, 'count': count})
+        few.append({'name': name, 'count': count, 'mode': mode})
 
     save_scores(scores)
     return jsonify({'success': True})

--- a/scores.json
+++ b/scores.json
@@ -1,1 +1,2 @@
-{"fastest": [{"name": "Bailey", "time": 410}, {"name": "Lorraine", "time": 627}], "fewest": [{"name": "Bailey", "count": 88}, {"name": "Lorraine", "count": 94}]}
+{"fastest": [{"name": "Bailey", "time": 410, "mode": "Easy"}, {"name": "Lorraine", "time": 627, "mode": "Hard"}], "fewest": [{"name": "Bailey", "count": 88, "mode": "Easy"}, {"name": "Lorraine", "count": 94, "mode": "Hard"}]}
+

--- a/templates/board.html
+++ b/templates/board.html
@@ -134,6 +134,7 @@
         let potentialTime = 0;
         let potentialCount = 0;
         let missedOpportunity = null;
+        const mode = '{{ "Easy" if show_products else "Hard" }}';
 
         let audioCtx;
         function playTone(freq, duration, type = 'sine', delay = 0) {
@@ -437,7 +438,7 @@
                             fetch('/submit_score', {
                                 method: 'POST',
                                 headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({ name, time, count })
+                                body: JSON.stringify({ name, time, count, mode })
                             }).then(() => {
                                 document.getElementById('score-message').textContent = 'Score saved!';
                                 document.getElementById('submit-score').disabled = true;

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -36,18 +36,18 @@
         <div class="time-board">
             <h2>Fastest Times</h2>
             <table>
-                <tr><th>Rank</th><th>Name</th><th>Time </th></tr>
+                <tr><th>Rank</th><th>Name</th><th>Mode</th><th>Time </th></tr>
                 {% for entry in fastest %}
-                <tr><td>{{ loop.index }}</td><td>{{ entry.name }}</td><td>{{ entry.formatted_time }}</td></tr>
+                <tr><td>{{ loop.index }}</td><td>{{ entry.name }}</td><td>{{ entry.mode }}</td><td>{{ entry.formatted_time }}</td></tr>
                 {% endfor %}
             </table>
         </div>
         <div class="count-board">
             <h2>Fewest Correct Squares</h2>
             <table>
-                <tr><th>Rank</th><th>Name</th><th>Squares</th></tr>
+                <tr><th>Rank</th><th>Name</th><th>Mode</th><th>Squares</th></tr>
                 {% for entry in fewest %}
-                <tr><td>{{ loop.index }}</td><td>{{ entry.name }}</td><td>{{ entry.count }}</td></tr>
+                <tr><td>{{ loop.index }}</td><td>{{ entry.name }}</td><td>{{ entry.mode }}</td><td>{{ entry.count }}</td></tr>
                 {% endfor %}
             </table>
         </div>


### PR DESCRIPTION
## Summary
- track which mode (Easy/Hard) players used when saving scores
- show the mode on the leaderboard tables
- send mode information from the bingo board when submitting scores
- update sample `scores.json` data

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py bingo_board.py`


------
https://chatgpt.com/codex/tasks/task_e_6855dec0a5a4832b8c6dec33f844cdb2