### PR TITLE
Add Dockerfile for Fly.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["gunicorn", "app:app", "--bind", "0.0.0.0:8080"]


### PR DESCRIPTION
## Summary
- add Dockerfile to build the app image for Fly.io

## Testing
- `flyctl deploy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f8a8c9ec832bbf74406d1d02cc46