### PR TITLE
Fix Fly.io build by adding gunicorn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask
+gunicorn


### PR DESCRIPTION
## Summary
- add `gunicorn` to `requirements.txt` so the Dockerfile can run `gunicorn`

## Testing
- `flake8` *(fails: E302, E305, E501)*

------
https://chatgpt.com/codex/tasks/task_e_6855f1ae29d4832bbb3c6449db367093