### PR TITLE
Fix score file path to be independent of CWD

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,16 +2,20 @@ from flask import Flask, render_template, request, jsonify
 import json
 import os
 
-SCORE_FILE = 'scores.json'
+# Determine the path to the scores file relative to this script so that the app
+# works no matter where it's launched from.
+SCORE_FILE = os.path.join(os.path.dirname(__file__), 'scores.json')
 
-def load_scores():
-    if not os.path.exists(SCORE_FILE):
+def load_scores(path=SCORE_FILE):
+    """Load the score data from disk."""
+    if not os.path.exists(path):
         return {"fastest": [], "fewest": []}
-    with open(SCORE_FILE, 'r') as f:
+    with open(path, 'r') as f:
         return json.load(f)
 
-def save_scores(data):
-    with open(SCORE_FILE, 'w') as f:
+def save_scores(data, path=SCORE_FILE):
+    """Persist the score data to disk."""
+    with open(path, 'w') as f:
         json.dump(data, f)
 
 app = Flask(__name__)


### PR DESCRIPTION
## Summary
- make score file path relative to app.py
- accept path override in score load/save helpers

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 Multiplication_Bingo/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6855fe2e8b40832b88385242871c6df2